### PR TITLE
Fixes #34

### DIFF
--- a/src/DeuxEtageres.cpp
+++ b/src/DeuxEtageres.cpp
@@ -67,8 +67,8 @@ struct DeuxEtageres : Module {
     const float vfmin = -4.;
     const float vfmax = 6.;
 
-    const float gmax = -1.;
-    const float gmin = 1.;
+    const float gmax = 1.;
+    const float gmin = -1.;
 
     configParam(DeuxEtageres::FREQ4_PARAM, vfmin, vfmax, 0., "");
     configParam(DeuxEtageres::GAIN4_PARAM, gmin, gmax, 0., "");
@@ -128,7 +128,7 @@ void DeuxEtageres::process(const ProcessArgs &args) {
   float freq3 = clamp(g_cutoff + params[FREQ3_PARAM].getValue() + inputs[FREQ3_INPUT].getNormalVoltage(0.), -4.0f, 6.0f);
   float freq4 = clamp(g_cutoff + params[FREQ4_PARAM].getValue() + inputs[FREQ4_INPUT].getNormalVoltage(0.), -4.0f, 6.0f);
 
-  float reso2 = clamp(g_cutoff + params[Q2_PARAM].getValue() + inputs[Q3_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
+  float reso2 = clamp(g_cutoff + params[Q2_PARAM].getValue() + inputs[Q2_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
   float reso3 = clamp(g_cutoff + params[Q3_PARAM].getValue() + inputs[Q3_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
 
   for (int i = 0; i < 2; i++) {
@@ -168,10 +168,10 @@ void DeuxEtageres::process(const ProcessArgs &args) {
     float bp3out = bp3Filter[i].processAudioSample(dry, 1);
     float hpout = hpFilter[i].processAudioSample(dry, 1);
 
-    float lpgain = pow(20., -gain1);
-    float bp2gain = pow(20., -gain2);
-    float bp3gain = pow(20., -gain3);
-    float hpgain = pow(20., -gain4);
+    float lpgain = pow(20., gain1);
+    float bp2gain = pow(20., gain2);
+    float bp3gain = pow(20., gain3);
+    float hpgain = pow(20., gain4);
 
     float sumout = lpout * lpgain + hpout * hpgain + bp2out * bp2gain + bp3out * bp3gain;
 

--- a/src/Etagere.cpp
+++ b/src/Etagere.cpp
@@ -122,7 +122,7 @@ void Etagere::process(const ProcessArgs &args) {
   float freq3 = clamp(g_cutoff + params[FREQ3_PARAM].getValue() + inputs[FREQ3_INPUT].getNormalVoltage(0.), -4.0f, 6.0f);
   float freq4 = clamp(g_cutoff + params[FREQ4_PARAM].getValue() + inputs[FREQ4_INPUT].getNormalVoltage(0.), -4.0f, 6.0f);
 
-  float reso2 = clamp(g_cutoff + params[Q2_PARAM].getValue() + inputs[Q3_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
+  float reso2 = clamp(g_cutoff + params[Q2_PARAM].getValue() + inputs[Q2_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
   float reso3 = clamp(g_cutoff + params[Q3_PARAM].getValue() + inputs[Q3_INPUT].getNormalVoltage(0.) / 10.0, 0.0f, 1.0f);
 
   lpFilter.setQ(.5); //Resonance(.5);

--- a/src/Etagere.cpp
+++ b/src/Etagere.cpp
@@ -77,8 +77,8 @@ struct Etagere : Module {
     const float vfmin = -4.;
     const float vfmax = 6.;
 
-    const float gmax = -1.;
-    const float gmin = 1.;
+    const float gmax = 1.;
+    const float gmin = -1.;
 
     configParam(Etagere::FREQ4_PARAM, vfmin, vfmax, 0., "");
     configParam(Etagere::GAIN4_PARAM, gmin, gmax, 0., "");
@@ -110,7 +110,7 @@ struct Etagere : Module {
 
 void Etagere::process(const ProcessArgs &args) {
 
-  float g_gain = clamp(inputs[GAIN5_INPUT].getNormalVoltage(0.), -1.0, 1.0);
+  float g_gain = clamp(inputs[GAIN5_INPUT].getNormalVoltage(0.), -1.0f, 1.0f);
   float gain1 = clamp(g_gain + params[GAIN1_PARAM].getValue() + inputs[GAIN1_INPUT].getNormalVoltage(0.) / 10.0, -1.0f, 1.0f);
   float gain2 = clamp(g_gain + params[GAIN2_PARAM].getValue() + inputs[GAIN2_INPUT].getNormalVoltage(0.) / 10.0, -1.0f, 1.0f);
   float gain3 = clamp(g_gain + params[GAIN3_PARAM].getValue() + inputs[GAIN3_INPUT].getNormalVoltage(0.) / 10.0, -1.0f, 1.0f);
@@ -179,10 +179,10 @@ void Etagere::process(const ProcessArgs &args) {
             printf("%f %f %f %f\n", lp_cutoff, bp2_cutoff, bp3_cutoff, hp_cutoff);
         }
 */
-  float lpgain = pow(20., -gain1);
-  float bp2gain = pow(20., -gain2);
-  float bp3gain = pow(20., -gain3);
-  float hpgain = pow(20., -gain4);
+  float lpgain = pow(20., gain1);
+  float bp2gain = pow(20., gain2);
+  float bp3gain = pow(20., gain3);
+  float hpgain = pow(20., gain4);
 
   outputs[LP_OUTPUT].value = lpout * lpgain;
   outputs[BP2_OUTPUT].setVoltage(bp2out * bp2gain);


### PR DESCRIPTION
`gmin` and `gmax` were mixed up and an incorrect sign caused the Gain CV input to be inverted. There was a typo, `inputs[Q3_INPUT]` was used twice instead of `inputs[Q2_INPUT]`.