### PR TITLE
Fixes noise level and missing tag

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -129,7 +129,9 @@
       "slug": "DeuxEtageres",
       "name": "DeuxEtageres",
       "description": "Stereo EQ",
-      "tags": []
+        "tags": [
+          "Equalizer"
+        ]
     },
     {
       "slug": "Etagere",

--- a/src/Sssh.cpp
+++ b/src/Sssh.cpp
@@ -62,7 +62,7 @@ void Sssh::process(const ProcessArgs &args) {
 
     // Gaussian noise generator
     // TO DO: check correlation between calls
-    float noise = 5.0 * random::normal();
+    float noise = 2.0 * random::normal();
 
     if (i == 0) {
       trig[0] = inputs[TRIG1_INPUT].getNormalVoltage(0);


### PR DESCRIPTION
Fixes issue #26 in accordance with https://github.com/VCVRack/AudibleInstruments/blob/v1/src/Kinks.cpp#L42. Obviously a normal distribution can produce arbitrary large values, but this fix should keep the most probable values within +/-10V. The +/-15V before seemed a bit hot.

Fixes issue #31 by adding tag.